### PR TITLE
fix docker ci

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -42,11 +42,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # - name: Login to Docker Hub
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push [${{ env.DOCKER_IMAGE_NAME }}]
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -3,7 +3,7 @@ name: docker-ci
 on:
   push:
     branches:
-      - main
+      - '*'
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   # enables manual trigger
@@ -51,6 +51,7 @@ jobs:
       - name: Build and push [${{ env.DOCKER_IMAGE_NAME }}]
         uses: docker/build-push-action@v6
         with:
+          file: Dockerfile.alpine
           build-args: |
             VERSION_COMMIT=${{ steps.get-docker-tag.outputs.tag }}
           # if false it will only build

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -11,7 +11,8 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir --no-dependencies -r requirements.txt
 
-COPY src gulp_cfg_template.json MANIFEST.in pyproject.toml .
-RUN --mount=source=.git,target=.git,type=bind pip install -e .
+COPY .git src gulp_cfg_template.json MANIFEST.in pyproject.toml .
+RUN pip install -e .
+RUN rm -fr .git
 
 CMD [ "gulp", "--bind-to", "0.0.0.0", "8080" ]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -11,7 +11,8 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir --no-dependencies -r requirements.txt
 
-COPY .git src gulp_cfg_template.json MANIFEST.in pyproject.toml .
+COPY src gulp_cfg_template.json MANIFEST.in pyproject.toml .
+COPY .git /.git
 RUN pip install -e .
 RUN rm -fr .git
 


### PR DESCRIPTION
this is causing troubles `--mount=source=.git,target=.git,type=bind`, as far as i understood it's needed for the `-e` flag, but i never seen it before in a docker file

see
* https://github.com/pypa/setuptools-scm/issues/77
* https://github.com/nicolabs/nicobot/issues/53